### PR TITLE
Always display vertical scroll bar

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,3 +1,7 @@
+html {
+    overflow-y: scroll;
+}
+
 pre {
     padding: 0;
 }


### PR DESCRIPTION
The theme can be perceived as kind of jumpy when switching between pages that force a scroll bar and pages that don't. This fix proposes to always display a vertical scroll bar to avoid this behavior.
