### PR TITLE
Update single.html to fix TAG link generation

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -40,7 +40,7 @@
 
 
         <aside>
-          {{ with .Params.tags }}<div class="section">{{ range . }}<a href="{{ $.Site.BaseURL}}tags/{{ . }}" class="tag">{{ . }}</a> {{ end }}</div>{{ end }}
+          {{ with .Params.tags }}<div class="section">{{ range . }}<a href="{{ $.Site.BaseURL}}tags/{{ lower . | urlize }}/" class="tag">{{ . }}</a> {{ end }}</div>{{ end }}
 
           <div class="section share">
             <a href="http://www.facebook.com/sharer.php?src=bm&u={{ .Permalink }}&t={{ .Title }}" onclick="window.open(this.href, 'PCwindow', 'width=550, height=350, menubar=no, toolbar=no, scrollbars=yes'); return false;"><i class="fa fa-facebook"></i></a>


### PR DESCRIPTION
Currently, tag link generation is broken when the tags are cased or have spaces.  This fixes the URL generation to match the tag directory structure.
