### PR TITLE
images were not showing in single post view

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,7 @@
         <meta itemprop="description" content="{{ .Summary }}">
         <meta itemprop="url" content="{{ .Permalink }}">
         <div itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
-          <meta itemprop="url" content="{{ $.Site.BaseURL }}images/{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}" />
+          <img src="{{ with .Params.image }}{{ $.Site.BaseURL }}images/{{ . }}{{ else }}data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs={{ end }}" style="{{ with .Params.image }}{{ else }}height:0px;width:0px;{{ end }}" />
           <meta itemprop="width" content="800">
           <meta itemprop="height" content="800">
         </div>


### PR DESCRIPTION
Hi, I was using your template, it is very cool. But I couldn't see images in individual posts, so I have make a small change to fix this. Now if you have an image in the post, it will be shown, and if you dont set an specific image, it will show a blank image (without having to request another static file) with 0px height.
