### PR TITLE
don't show read more link in case post is not truncated

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -14,7 +14,9 @@
   {{ with .Params.thumbnail }}<a href="{{ $.Permalink }}" class="thumb" title="{{ $.Title }}" style="background-image: url({{ $.Site.BaseURL }}{{ . }});"></a>{{ end }}
   <div class="summary">{{ .Summary }}</div>
 
+  {{ if .Truncated }}
   <footer>
     <a href="{{ .Permalink }}" title="{{ .Title }}">Read More…</a>
   </footer>
+  {{ end }}
 </article>


### PR DESCRIPTION
As seen in [documentation](https://gohugo.io/content-management/summaries/#example-first-10-articles-with-summaries) example:
```  go
{{ range first 10 .Data.Pages }}
    <article>
      <!-- this <div> includes the title summary -->
      <div>
        <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
        {{ .Summary }}
      </div>
      {{ if .Truncated }}
      <!-- This <div> includes a read more link, but only if the summary is truncated... -->
      <div>
        <a href="{{ .RelPermalink }}">Read More…</a>
      </div>
      {{ end }}
    </article>
{{ end }}
```