### PR TITLE
Fix min_version

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Bootstrap3 based theme for Hugo."
 homepage = "https://github.com/dim0627/hugo_theme_beg"
 tags = ["blog"]
 features = ["responsive", "thumbnail", "syntax highlight", "structured data", "ogp", "twitter cards"]
-min_version = 0.42.2
+min_version = "0.42.2"
 
 [author]
   name = "Daisuke Tsuji"


### PR DESCRIPTION
gohugoio/hugo#6162

```
WARN 2019/08/17 12:44:54 Failed to read module config for "beg" in "themes/beg/theme.toml": unmarshal failed: Near line 8 (last key parsed 'min_version'): Invalid float value: "0.42.2"
```